### PR TITLE
feat(flags): update fetchFlags to include endpoint path

### DIFF
--- a/flags.go
+++ b/flags.go
@@ -185,7 +185,7 @@ func (c *Client) refreshCache() {
 }
 
 func (c *Client) fetchFlags() (*ApiResponse, error) {
-	req, err := http.NewRequest("GET", c.baseURL, nil)
+	req, err := http.NewRequest("GET", fmt.Sprintf("%s/flags", c.baseURL), nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Update the fetchFlags method to construct the request URL by 
appending "/flags" to the base URL. This change ensures that 
the correct endpoint is called when fetching flags from the 
API, improving the functionality of the client.