### PR TITLE
feat: Update base URL for flags API

### DIFF
--- a/flags.go
+++ b/flags.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	baseURL    = "https://api.flags.gg/v1"
+	baseURL    = "https://api.flags.gg"
 	maxRetries = 3
 )
 


### PR DESCRIPTION
Updates the base URL for the flags API from
"https://api.flags.gg/v1" to "https://api.flags.gg". This change
simplifies the URL and removes the version number, as the API is
currently at version 1 and this change is not expected to break
existing clients.