### PR TITLE
feat(flags): Introduce cache system and refactor client

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -1,0 +1,262 @@
+package cache
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"github.com/bugfixes/go-bugfixes/logs"
+	"github.com/flags-gg/go-flags/flag"
+	_ "modernc.org/sqlite"
+	"time"
+)
+
+func getDBClient(db *sql.DB) (*sql.DB, error) {
+	if db != nil {
+		return db, nil
+	}
+
+	db, err := sql.Open("sqlite", "/tmp/flags.db?_pragma=busy_timeout=1000&pragma=journal_mode=WAL")
+	if err != nil {
+		return nil, logs.Errorf("failed to open database: %v", err)
+	}
+	return db, nil
+}
+
+type System struct {
+	Context context.Context
+
+	DB *sql.DB
+}
+
+func NewSystem() *System {
+	db, err := getDBClient(nil)
+	if err != nil {
+		return nil
+	}
+
+	return &System{
+		Context: context.Background(),
+		DB:      db,
+	}
+}
+
+func (s *System) SetContext(ctx context.Context) {
+	s.Context = ctx
+}
+
+func (s *System) InitDB() error {
+	db, err := getDBClient(s.DB)
+	if err != nil {
+		return logs.Errorf("failed to get database client: %v", err)
+	}
+
+	//defer func() {
+	//	if err := db.Close(); err != nil {
+	//		_ = logs.Errorf("failed to close database: %v", err)
+	//	}
+	//}()
+
+	if _, err := db.Exec(`PRAGMA foreign_keys = ON`); err != nil {
+		_ = logs.Errorf("failed to enable foreign keys: %v", err)
+		//if err := db.Close(); err != nil {
+		//	_ = logs.Errorf("failed to close database: %v", err)
+		//}
+		return nil
+	}
+
+	tx, err := db.Begin()
+	if err != nil {
+		return logs.Errorf("failed to begin transaction: %v", err)
+	}
+	defer func() {
+		if err := tx.Rollback(); err != nil {
+			if !errors.Is(err, sql.ErrTxDone) {
+				_ = logs.Errorf("failed to rollback transaction: %v", err)
+			}
+		}
+	}()
+
+	if _, err := tx.Exec(`
+    CREATE TABLE IF NOT EXISTS flags (
+        name TEXT PRIMARY KEY,
+        enabled BOOLEAN NOT NULL DEFAULT FALSE,
+        updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+    )`); err != nil {
+		return logs.Errorf("failed to create flags table: %v", err)
+	}
+
+	if _, err := tx.Exec(`
+	CREATE TABLE IF NOT EXISTS cache_metadata (
+		key TEXT PRIMARY KEY,
+		value TEXT
+	)`); err != nil {
+		return logs.Errorf("failed to create cache_metadata table: %v", err)
+	}
+
+	if _, err := tx.Exec(`CREATE INDEX IF NOT EXISTS idx_flags_updated ON flags(updated_at)`); err != nil {
+		return logs.Errorf("failed to create index: %v", err)
+	}
+
+	return tx.Commit()
+}
+
+func (s *System) deleteAllFlags() error {
+	db, err := getDBClient(s.DB)
+	if err != nil {
+		return logs.Errorf("failed to get database client: %v", err)
+	}
+
+	//defer func() {
+	//	if err := db.Close(); err != nil {
+	//		_ = logs.Errorf("failed to close database: %v", err)
+	//	}
+	//}()
+
+	tx, err := db.Begin()
+	if err != nil {
+		return logs.Errorf("failed to begin transaction: %v", err)
+	}
+	defer func() {
+		if err := tx.Rollback(); err != nil {
+			if !errors.Is(err, sql.ErrTxDone) {
+				_ = logs.Errorf("failed to rollback transaction: %v", err)
+			}
+		}
+	}()
+	if _, err := tx.Exec(`DELETE FROM flags`); err != nil {
+		return logs.Errorf("failed to delete flags: %v", err)
+	}
+
+	return tx.Commit()
+}
+
+func (s *System) Refresh(flags []flag.FeatureFlag, intervalAllowed int) error {
+	if err := s.deleteAllFlags(); err != nil {
+		return err
+	}
+
+	db, err := getDBClient(s.DB)
+	if err != nil {
+		return logs.Errorf("failed to get database client: %v", err)
+	}
+
+	//defer func() {
+	//	if err := db.Close(); err != nil {
+	//		_ = logs.Errorf("failed to close database: %v", err)
+	//	}
+	//}()
+
+	tx, err := db.Begin()
+	if err != nil {
+		return logs.Errorf("failed to begin transaction: %v", err)
+	}
+	stmt, err := tx.Prepare(`INSERT INTO flags (name, enabled, updated_at) VALUES ($1, $2, $3)`)
+	if err != nil {
+		return logs.Errorf("failed to prepare statement: %v", err)
+
+	}
+	defer func() {
+		if err := stmt.Close(); err != nil {
+			_ = logs.Errorf("failed to close statement: %v", err)
+		}
+	}()
+
+	now := time.Now().Unix()
+	for _, flag := range flags {
+		if _, err := stmt.Exec(flag.Details.Name, flag.Enabled, now); err != nil {
+			return logs.Errorf("failed to insert flag: %v", err)
+		}
+	}
+	if _, err := tx.Exec(`INSERT OR REPLACE INTO cache_metadata(key, value) VALUES('next_refresh_time', ?), ('cache_ttl', ?)`, time.Now().Add(time.Duration(intervalAllowed)*time.Second).Unix(), intervalAllowed); err != nil {
+		return logs.Errorf("failed to insert cache metadata: %v", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return logs.Errorf("failed to commit transaction: %v", err)
+	}
+
+	return nil
+}
+
+func (s *System) ShouldRefreshCache() bool {
+	db, err := getDBClient(s.DB)
+	if err != nil {
+		return true
+	}
+
+	//defer func() {
+	//	if err := db.Close(); err != nil {
+	//		_ = logs.Errorf("failed to close database: %v", err)
+	//	}
+	//}()
+
+	var nextRefreshTime int64
+	if err := db.QueryRow(`SELECT CAST(value AS INTEGER) FROM cache_metadata WHERE key = 'next_refresh_time'`).Scan(&nextRefreshTime); err != nil {
+		return true
+	}
+
+	return time.Now().Unix() > nextRefreshTime
+}
+
+func (s *System) Get(name string) (bool, bool) {
+	db, err := getDBClient(s.DB)
+	if err != nil {
+		return false, false
+	}
+
+	//defer func() {
+	//	if err := db.Close(); err != nil {
+	//		_ = logs.Errorf("failed to close database: %v", err)
+	//	}
+	//}()
+
+	var enabled bool
+	if err := db.QueryRow(`SELECT enabled FROM flags WHERE name = $1 AND updated_at > (SELECT CAST(value AS INTEGER) FROM cache_metadata WHERE key = 'cache_ttl')`, name).Scan(&enabled); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return false, false
+		}
+		return false, false
+	}
+	return enabled, true
+}
+
+func (s *System) GetAll() ([]flag.FeatureFlag, error) {
+	db, err := getDBClient(s.DB)
+	if err != nil {
+		return nil, logs.Errorf("failed to get database client: %v", err)
+	}
+
+	defer func() {
+		if err := db.Close(); err != nil {
+			_ = logs.Errorf("failed to close database: %v", err)
+		}
+	}()
+
+	var flags []flag.FeatureFlag
+	rows, err := db.Query(`SELECT name, enabled FROM flags`)
+	if err != nil {
+		return nil, logs.Errorf("failed to query database: %v", err)
+	}
+	defer func() {
+		if err := rows.Close(); err != nil {
+			_ = logs.Errorf("failed to close database rows: %v", err)
+		}
+	}()
+
+	for rows.Next() {
+		var name string
+		var enabled bool
+		if err := rows.Scan(&name, &enabled); err != nil {
+			return nil, logs.Errorf("failed to scan database rows: %v", err)
+		}
+
+		flags = append(flags, flag.FeatureFlag{
+			Enabled: enabled,
+			Details: flag.Details{
+				Name: name,
+			},
+		})
+	}
+
+	return flags, nil
+}

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -162,8 +162,8 @@ func (s *System) Refresh(flags []flag.FeatureFlag, intervalAllowed int) error {
 	}()
 
 	now := time.Now().Unix()
-	for _, flag := range flags {
-		if _, err := stmt.Exec(flag.Details.Name, flag.Enabled, now); err != nil {
+	for _, f := range flags {
+		if _, err := stmt.Exec(f.Details.Name, f.Enabled, now); err != nil {
 			return logs.Errorf("failed to insert flag: %v", err)
 		}
 	}

--- a/flag/flag.go
+++ b/flag/flag.go
@@ -1,0 +1,11 @@
+package flag
+
+type Details struct {
+	Name string `json:"name"`
+	ID   string `json:"id"`
+}
+
+type FeatureFlag struct {
+	Enabled bool    `json:"enabled"`
+	Details Details `json:"details"`
+}

--- a/flags.go
+++ b/flags.go
@@ -1,13 +1,15 @@
 package flags
 
 import (
-	"database/sql"
+	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"github.com/bugfixes/go-bugfixes/logs"
-	_ "modernc.org/sqlite"
+	"github.com/flags-gg/go-flags/cache"
+	"github.com/flags-gg/go-flags/flag"
 	"net/http"
+	"os"
+	"strings"
 	"sync"
 	"time"
 )
@@ -25,23 +27,17 @@ type Auth struct {
 
 type Flag struct {
 	Name   string
-	client *Client
+	Client *Client
 }
 
 type Client struct {
 	baseURL      string
 	httpClient   *http.Client
-	db           *sql.DB
+	Cache        *cache.System
 	maxRetries   int
 	mutex        *sync.RWMutex
 	circuitState CircuitState
 	auth         Auth
-}
-
-type Cache struct {
-	flags           map[string]bool
-	nextRefreshTime time.Time
-	mutex           sync.RWMutex
 }
 
 type CircuitState struct {
@@ -51,54 +47,16 @@ type CircuitState struct {
 }
 
 type ApiResponse struct {
-	IntervalAllowed int           `json:"intervalAllowed"`
-	SecretMenu      SecretMenu    `json:"secretMenu"`
-	Flags           []FeatureFlag `json:"flags"`
+	IntervalAllowed int                `json:"intervalAllowed"`
+	Flags           []flag.FeatureFlag `json:"flags"`
 }
-type FlagDetails struct {
-	Name string `json:"name"`
-	ID   string `json:"id"`
-}
-type SecretMenu struct {
-	Sequence []string `json:"sequence"`
-}
-type FeatureFlag struct {
-	Enabled bool        `json:"enabled"`
-	Details FlagDetails `json:"details"`
-}
-
 type Option func(*Client)
 
-func getDBClient(db *sql.DB) (*sql.DB, error) {
-	if db != nil {
-		return db, nil
-	}
-
-	db, err := sql.Open("sqlite", "/tmp/flags.db?_pragma=busy_timeout=1000&pragma=journal_mode=WAL")
-	if err != nil {
-		return nil, logs.Errorf("failed to open database: %v", err)
-	}
-	return db, nil
-}
-
 func NewClient(opts ...Option) *Client {
-	db, err := getDBClient(nil)
-	if err != nil {
-		return nil
-	}
-
-	if _, err := db.Exec(`PRAGMA foreign_keys = ON`); err != nil {
-		_ = logs.Errorf("failed to enable foreign keys: %v", err)
-		if err := db.Close(); err != nil {
-			_ = logs.Errorf("failed to close database: %v", err)
-		}
-		return nil
-	}
-	if err := initDB(db); err != nil {
+	c := cache.NewSystem()
+	c.SetContext(context.Background())
+	if err := c.InitDB(); err != nil {
 		_ = logs.Errorf("failed to initialize database: %v", err)
-		if err := db.Close(); err != nil {
-			_ = logs.Errorf("failed to close database: %v", err)
-		}
 		return nil
 	}
 
@@ -107,7 +65,7 @@ func NewClient(opts ...Option) *Client {
 		httpClient: &http.Client{
 			Timeout: 10 * time.Second,
 		},
-		db:         db,
+		Cache:      c,
 		maxRetries: maxRetries,
 		mutex:      &sync.RWMutex{},
 		circuitState: CircuitState{
@@ -138,182 +96,50 @@ func WithAuth(auth Auth) Option {
 	}
 }
 
-func initDB(db *sql.DB) error {
-	db, err := getDBClient(db)
-	if err != nil {
-		return logs.Errorf("failed to get database client: %v", err)
-	}
-
-	tx, err := db.Begin()
-	if err != nil {
-		return logs.Errorf("failed to begin transaction: %v", err)
-	}
-	defer func() {
-		if err := tx.Rollback(); err != nil {
-			if !errors.Is(err, sql.ErrTxDone) {
-				_ = logs.Errorf("failed to rollback transaction: %v", err)
-			}
-		}
-	}()
-
-	if _, err := tx.Exec(`
-    CREATE TABLE IF NOT EXISTS flags (
-        name TEXT PRIMARY KEY,
-        enabled BOOLEAN NOT NULL DEFAULT FALSE,
-        updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
-    )`); err != nil {
-		return logs.Errorf("failed to create flags table: %v", err)
-	}
-
-	if _, err := tx.Exec(`
-	CREATE TABLE IF NOT EXISTS cache_metadata (
-		key TEXT PRIMARY KEY,
-		value TEXT
-	)`); err != nil {
-		return logs.Errorf("failed to create cache_metadata table: %v", err)
-	}
-
-	if _, err := tx.Exec(`CREATE INDEX IF NOT EXISTS idx_flags_updated ON flags(updated_at)`); err != nil {
-		return logs.Errorf("failed to create index: %v", err)
-	}
-
-	return tx.Commit()
-}
-
 func (c *Client) Is(name string) *Flag {
 	return &Flag{
 		Name:   name,
-		client: c,
+		Client: c,
 	}
 }
 
+// get all flags
+func (c *Client) List() ([]flag.FeatureFlag, error) {
+	flags, err := c.Cache.GetAll()
+	if err != nil {
+		return nil, err
+	}
+
+	return flags, nil
+}
+
+// flag specific enabled
 func (f *Flag) Enabled() bool {
-	return f.client.isEnabled(f.Name)
+	return f.Client.isEnabled(f.Name)
 }
 
 func (c *Client) isEnabled(name string) bool {
-	if c.shouldRefreshCache() {
-		c.refreshCache()
+	if c.Cache.ShouldRefreshCache() {
+		if err := c.refetch(); err != nil {
+			_ = logs.Errorf("failed to refetch flags: %v", err)
+			return false
+		}
 	}
 
-	enabled, exists := c.checkCache(name)
+	// check local
+	localFlags := buildLocal()
+	for lname, enabled := range localFlags {
+		if lname == name {
+			return enabled
+		}
+	}
+
+	// check cache
+	enabled, exists := c.Cache.Get(name)
 	if !exists {
 		return false
 	}
 	return enabled
-}
-
-func (c *Client) shouldRefreshCache() bool {
-	db, err := getDBClient(c.db)
-	if err != nil {
-		return true
-	}
-
-	var nextRefreshTime int64
-	if err := db.QueryRow(`SELECT CAST(value AS INTEGER) FROM cache_metadata WHERE key = 'next_refresh_time'`).Scan(&nextRefreshTime); err != nil {
-		return true
-	}
-
-	return time.Now().Unix() > nextRefreshTime
-}
-
-func (c *Client) checkCache(name string) (bool, bool) {
-	db, err := getDBClient(c.db)
-	if err != nil {
-		return false, false
-	}
-
-	var enabled bool
-	if err := db.QueryRow(`SELECT enabled FROM flags WHERE name = $1 AND updated_at > (SELECT CAST(value AS INTEGER) FROM cache_metadata WHERE key = 'cache_ttl')`, name).Scan(&enabled); err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			return false, false
-		}
-		return false, false
-	}
-	return enabled, true
-}
-
-func (c *Client) refreshCache() {
-	db, err := getDBClient(c.db)
-	if err != nil {
-		_ = logs.Errorf("failed to get database client: %v", err)
-		return
-	}
-
-	if c.circuitState.isOpen {
-		if time.Since(c.circuitState.lastFailure) < 10*time.Second {
-			return
-		}
-		c.circuitState.isOpen = false
-		c.circuitState.failureCount = 0
-	}
-
-	var apiResp *ApiResponse
-	for retry := 0; retry < c.maxRetries; retry++ {
-		apiResp, err = c.fetchFlags()
-		if err == nil {
-			c.circuitState.failureCount = 0
-			break
-		}
-
-		c.circuitState.failureCount++
-		if c.circuitState.failureCount >= c.maxRetries {
-			c.circuitState.isOpen = true
-			c.circuitState.lastFailure = time.Now()
-			return
-		}
-
-		time.Sleep(time.Duration(retry+1) * time.Second)
-	}
-
-	if err != nil || apiResp == nil {
-		_ = logs.Errorf("failed to fetch flags: %v", err)
-		return
-	}
-
-	tx, err := db.Begin()
-	if err != nil {
-		_ = logs.Errorf("failed to begin transaction: %v", err)
-		return
-	}
-	defer func() {
-		if err := tx.Rollback(); err != nil {
-			if !errors.Is(err, sql.ErrTxDone) {
-				_ = logs.Errorf("failed to rollback transaction: %v", err)
-			}
-		}
-	}()
-	if _, err := tx.Exec(`DELETE FROM flags`); err != nil {
-		_ = logs.Errorf("failed to delete flags: %v", err)
-		return
-	}
-	stmt, err := tx.Prepare(`INSERT INTO flags (name, enabled, updated_at) VALUES ($1, $2, $3)`)
-	if err != nil {
-		_ = logs.Errorf("failed to prepare statement: %v", err)
-		return
-	}
-	defer func() {
-		if err := stmt.Close(); err != nil {
-			_ = logs.Errorf("failed to close statement: %v", err)
-		}
-	}()
-
-	now := time.Now().Unix()
-	for _, flag := range apiResp.Flags {
-		if _, err := stmt.Exec(flag.Details.Name, flag.Enabled, now); err != nil {
-			_ = logs.Errorf("failed to insert flag: %v", err)
-			return
-		}
-	}
-	if _, err := tx.Exec(`INSERT OR REPLACE INTO cache_metadata(key, value) VALUES('next_refresh_time', ?), ('cache_ttl', ?)`, time.Now().Add(time.Duration(apiResp.IntervalAllowed)*time.Second).Unix(), apiResp.IntervalAllowed); err != nil {
-		_ = logs.Errorf("failed to insert cache metadata: %v", err)
-		return
-	}
-
-	if err := tx.Commit(); err != nil {
-		_ = logs.Errorf("failed to commit transaction: %v", err)
-		return
-	}
 }
 
 func (c *Client) fetchFlags() (*ApiResponse, error) {
@@ -360,4 +186,68 @@ func (c *Client) fetchFlags() (*ApiResponse, error) {
 		return nil, logs.Errorf("failed to decode body %v", err)
 	}
 	return &apiResp, nil
+}
+
+func (c *Client) refetch() error {
+	if c.circuitState.isOpen {
+		if time.Since(c.circuitState.lastFailure) < 10*time.Second {
+			return nil
+		}
+		c.circuitState.isOpen = false
+		c.circuitState.failureCount = 0
+	}
+
+	var apiResp *ApiResponse
+	var err error
+	for retry := 0; retry < c.maxRetries; retry++ {
+		apiResp, err = c.fetchFlags()
+		if err == nil {
+			c.circuitState.failureCount = 0
+			break
+		}
+
+		c.circuitState.failureCount++
+		if c.circuitState.failureCount >= c.maxRetries {
+			c.circuitState.isOpen = true
+			c.circuitState.lastFailure = time.Now()
+			return nil
+		}
+
+		time.Sleep(time.Duration(retry+1) * time.Second)
+	}
+
+	if err != nil || apiResp == nil {
+		return logs.Errorf("failed to fetch flags: %v", err)
+	}
+
+	if err := c.Cache.Refresh(apiResp.Flags, apiResp.IntervalAllowed); err != nil {
+		return logs.Errorf("failed to set cache: %v", err)
+	}
+
+	return nil
+}
+
+func buildLocal() map[string]bool {
+	col := make(map[string]bool)
+	for _, e := range os.Environ() {
+		pair := strings.SplitN(e, "=", 2)
+		if len(pair) != 2 {
+			continue
+		}
+
+		key, val := pair[0], pair[1]
+		if !strings.HasPrefix(key, "FLAGS_") {
+			continue
+		}
+
+		colKey := strings.ToLower(strings.TrimPrefix(key, "FLAGS_"))
+		col[colKey] = val == "true"
+
+		// replace _ with -
+		colKey = strings.ReplaceAll(colKey, "_", "-")
+		col[colKey] = val == "true"
+
+	}
+
+	return col
 }

--- a/flags.go
+++ b/flags.go
@@ -103,7 +103,7 @@ func (c *Client) Is(name string) *Flag {
 	}
 }
 
-// get all flags
+// List get all flags rather than just the one for the flag itself
 func (c *Client) List() ([]flag.FeatureFlag, error) {
 	flags, err := c.Cache.GetAll()
 	if err != nil {
@@ -113,7 +113,7 @@ func (c *Client) List() ([]flag.FeatureFlag, error) {
 	return flags, nil
 }
 
-// flag specific enabled
+// Enabled flag specific
 func (f *Flag) Enabled() bool {
 	return f.Client.isEnabled(f.Name)
 }

--- a/flags_test.go
+++ b/flags_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 	"time"
 )
@@ -15,7 +16,7 @@ func TestClient_Is(t *testing.T) {
 	if flag.Name != "test-flag" {
 		t.Errorf("Expected flag name to be 'test-flag', got %s", flag.Name)
 	}
-	if flag.client != client {
+	if flag.Client != client {
 		t.Error("Expected flag client to be set correctly")
 	}
 }
@@ -96,99 +97,81 @@ func TestFeatureFlags(t *testing.T) {
 	}
 }
 
-//func TestCaching(t *testing.T) {
-//	callCount := 0
-//	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-//		callCount++
-//		response := fmt.Sprintf(`{
-//			"intervalAllowed": 2,
-//			"secretMenu": {"sequence": ["b"]},
-//			"flags": [{"enabled": true, "details": {"name": "test-flag", "id": "%d"}}]
-//		}`, callCount)
-//		w.Header().Set("Content-Type", "application/json")
-//		_, _ = fmt.Fprintln(w, response)
-//	}))
-//	defer server.Close()
-//
-//	client := NewClient(WithBaseURL(server.URL), WithAuth(Auth{
-//		ProjectID:     "test-project",
-//		AgentID:       "test-agent",
-//		EnvironmentID: "test-environment",
-//	}))
-//
-//	// First call should hit the server
-//	r1 := client.Is("test-flag").Enabled()
-//	initialCallCount := callCount
-//	if !r1 {
-//		t.Errorf("Expected first call to return true, got false")
-//	}
-//	if initialCallCount != 1 {
-//		t.Errorf("Expected 1 server call, got %d", initialCallCount)
-//	}
-//
-//	// Second immediate call should use cache
-//	r2 := client.Is("test-flag").Enabled()
-//	if !r2 {
-//		t.Errorf("Expected second call to return true, got false")
-//	}
-//	if callCount != initialCallCount {
-//		t.Errorf("Expected cache hit (still 1 call), got %d calls", callCount)
-//	}
-//
-//	// Wait for cache to expire (intervalAllowed is 1 second)
-//	time.Sleep(3 * time.Second)
-//
-//	// This call should hit the server again
-//	r3 := client.Is("test-flag").Enabled()
-//	if !r3 {
-//		t.Errorf("Expected third call to return true, got false")
-//	}
-//	if callCount <= initialCallCount {
-//		t.Errorf("Expected cache hit (still %d call), got %d calls", initialCallCount, callCount)
-//	}
-//}
+func TestLocalFeatureFlags(t *testing.T) {
+	// Create a test server
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		response := `{
+			"intervalAllowed": 60,
+			"secretMenu": {"sequence": ["b","b","b"]},
+			"flags": [
+				{"enabled": true, "details": {"name": "enabled-flag", "id": "1"}},
+				{"enabled": false, "details": {"name": "disabled-flag", "id": "2"}},
+				{"enabled": true, "details": {"name": "local-flag", "id": "3"}},
+				{"enabled": false, "details": {"name": "local-override-flag", "id": "4"}}
+			]
+		}`
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprintln(w, response)
+	}))
+	defer server.Close()
 
-//func TestCircuitBreaker(t *testing.T) {
-//	failures := 0
-//	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-//		failures++
-//		w.WriteHeader(http.StatusInternalServerError)
-//	}))
-//	defer server.Close()
-//
-//	client := NewClient(
-//		WithBaseURL(server.URL),
-//		WithMaxRetries(3),
-//		WithAuth(Auth{
-//			ProjectID:     "test-project",
-//			AgentID:       "test-agent",
-//			EnvironmentID: "test-environment",
-//		}),
-//	)
-//
-//	// First attempt should trigger circuit breaker
-//	result := client.Is("any-flag").Enabled()
-//	if result != false {
-//		t.Error("Expected false when circuit breaker is triggered")
-//	}
-//	if failures != 3 {
-//		t.Errorf("Expected 3 failures before circuit breaker, got %d", failures)
-//	}
-//
-//	// Immediate retry should not hit the server due to open circuit
-//	initialFailures := failures
-//	client.Is("any-flag").Enabled()
-//	if failures != initialFailures {
-//		t.Error("Circuit breaker failed to prevent requests")
-//	}
-//
-//	// Wait for circuit to reset
-//	time.Sleep(11 * time.Second)
-//	client.Is("any-flag").Enabled()
-//	if failures <= initialFailures {
-//		t.Error("Circuit breaker failed to reset after timeout")
-//	}
-//}
+	client := NewClient(WithBaseURL(server.URL), WithAuth(Auth{
+		ProjectID:     "test-project",
+		AgentID:       "test-agent",
+		EnvironmentID: "test-environment",
+	}))
+
+	// set the local flag to false
+	if err := os.Setenv("FLAGS_LOCAL_FLAG", "false"); err != nil {
+		t.Error(err)
+	}
+
+	// set the local override flag to true
+	if err := os.Setenv("FLAGS_LOCAL_OVERRIDE_FLAG", "true"); err != nil {
+		t.Error(err)
+	}
+
+	tests := []struct {
+		name     string
+		flagName string
+		want     bool
+	}{
+		{
+			name:     "enabled flag returns true",
+			flagName: "enabled-flag",
+			want:     true,
+		},
+		{
+			name:     "disabled flag returns false",
+			flagName: "disabled-flag",
+			want:     false,
+		},
+		{
+			name:     "non-existent flag returns false",
+			flagName: "non-existent",
+			want:     false,
+		},
+		{
+			name:     "local flag returns false",
+			flagName: "local-flag",
+			want:     false,
+		},
+		{
+			name:     "local override flag returns true",
+			flagName: "local-override-flag",
+			want:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := client.Is(tt.flagName).Enabled()
+			if got != tt.want {
+				t.Errorf("Flag %s: got %v, want %v", tt.flagName, got, tt.want)
+			}
+		})
+	}
+}
 
 func TestErrorHandling(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
This commit introduces a new cache system to store feature flags and improves the `Client` struct by removing the `db` field and adding a `Cache` field instead.

The main changes are:

1. Added a new `cache` package that provides a `System` struct to manage the feature flag cache. This includes initializing the SQLite database, refreshing the cache, and deleting all flags.

2. Refactored the `Client` struct to use the new `Cache` system instead of the `db` field. This simplifies the client and makes it more modular.

3. Updated the `flags_test.go` file to use the new `Cache` system.

These changes improve the overall design and maintainability of the feature flag system.