### PR TITLE
feat: Add ability to set custom database file name

### DIFF
--- a/flags.go
+++ b/flags.go
@@ -54,11 +54,6 @@ type Option func(*Client)
 
 func NewClient(opts ...Option) *Client {
 	c := cache.NewSystem()
-	c.SetContext(context.Background())
-	if err := c.InitDB(); err != nil {
-		_ = logs.Errorf("failed to initialize database: %v", err)
-		return nil
-	}
 
 	client := &Client{
 		baseURL: baseURL,
@@ -77,6 +72,12 @@ func NewClient(opts ...Option) *Client {
 	for _, opt := range opts {
 		opt(client)
 	}
+	c.SetContext(context.Background())
+	if err := c.InitDB(); err != nil {
+		_ = logs.Errorf("failed to initialize database: %v", err)
+		return nil
+	}
+
 	return client
 }
 
@@ -93,6 +94,11 @@ func WithMaxRetries(maxRetries int) Option {
 func WithAuth(auth Auth) Option {
 	return func(c *Client) {
 		c.auth = auth
+	}
+}
+func SetFileName(fileName *string) Option {
+	return func(c *Client) {
+		c.Cache.SetFileName(fileName)
 	}
 }
 
@@ -244,12 +250,12 @@ func buildLocal() map[string]bool {
 		col[colKey] = val == "true"
 
 		// replace _ with -
-		colKey = strings.ReplaceAll(colKey, "_", "-")
-		col[colKey] = val == "true"
+		colKeyUnderscore := strings.ReplaceAll(colKey, "_", "-")
+		col[colKeyUnderscore] = val == "true"
 
 		// replace _ with <space>
-		colKey = strings.ReplaceAll(colKey, "_", " ")
-		col[colKey] = val == "true"
+		colKeySpace := strings.ReplaceAll(colKey, "_", " ")
+		col[colKeySpace] = val == "true"
 	}
 
 	return col


### PR DESCRIPTION
This change adds the ability to set a custom database file name for the feature flags client. Previously, the client was using a hardcoded file name `/tmp/flags.db`. Now, users can pass a custom file name using the `SetFileName` option when creating a new client.

The changes include:

- Added a new `SetFileName` option function to the `flags` package.
- Updated the `NewClient` function to accept the `SetFileName` option.
- Updated the `getDBClient` function in the `cache` package to use the provided file name or fall back to the default `/tmp/flags.db` file.
- Updated the `InitDB` function in the `cache` package to use the new `getDBClient` function.
- Updated the tests in `flags_test.go` to use the new `SetFileName` option.

This change allows users to customize the database file location, which can be useful for testing or deployment scenarios where the default location is not suitable.